### PR TITLE
updated script example in README to fix variable being escaped

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,40 @@
 # mac-device-id-to-model
+
 A list of known Mac model identifiers, scraped from Apple Support, that you can use to determine a Mac's marketing name (including model year). This can be useful in managment or other scripts.
 
 ## Why not use the old methods?
+
 ```
-curl -s https://support-sp.apple.com/sp/product?cc=` echo $DEVICE_SERIAL | cut -c 9-` 
+curl -s https://support-sp.apple.com/sp/product?cc=` echo $DEVICE_SERIAL | cut -c 9-`
 ```
+
 This one doesn't work with Apple's [new serial number](https://www.macrumors.com/2021/05/05/purple-iphone-12-randomized-serial-number/) format. EG with newer Apple Silicon / M1 / M1 Pro / M1 Max / 2021 Macs. They have not provided any alterntive.
 
 ```
 Read some random plist files!
 ```
+
 This changes each major OS version, and archtectecture, and is not reliable.
+
 ```
 Use MDM!
 ```
+
 Even if you use MDM, I do, you may find it useful to have the marketing name or model year in a shell script.
 
 ## How do I use it?
-However you like! You can curl the raw GitHub URL to get the most up-to-date list, then search for the line containing your model identifier such as `iMac21,2`. 
+
+However you like! You can curl the raw GitHub URL to get the most up-to-date list, then search for the line containing your model identifier such as `iMac21,2`.
 
 Here's an example:
+
 ```
 # Determine the model and year:
-DEIVCE_IDENTIFIER=$(sysctl hw.model | awk '{print $NF}')
-DEVICE_MODEL_CURL=$(curl -s "https://raw.githubusercontent.com/quacktacular/mac-device-id-to-model/main/models.txt" | grep "|$DEIVCE_IDENTIFIER\| \+\$DEIVCE_IDENTIFIER" | head -1 | cut -f1 -d"|")
+DEVICE_IDENTIFIER=$(sysctl hw.model | awk '{print $NF}')
+DEVICE_MODEL_CURL=$(curl -s "https://raw.githubusercontent.com/quacktacular/mac-device-id-to-model/main/models.txt" \
+  | grep "|$DEVICE_IDENTIFIER\| \+$DEVICE_IDENTIFIER" | head -1 | cut -f1 -d"|")
 if [[ $DEVICE_MODEL_CURL = *"("*")"* ]]; then
-  DEVICE_MODEL=$( echo $DEVICE_MODEL_CURL | cut -f1 -d"|" )	
+  DEVICE_MODEL=$( echo $DEVICE_MODEL_CURL | cut -f1 -d"|" )
   DEVICE_YEAR=$( echo "$DEVICE_MODEL" | grep -o -E '[0-9][0-9][0-9][0-9]' )
 else
   DEVICE_MODEL="Unknown Mac"
@@ -38,7 +47,9 @@ echo $DEVICE_YEAR
 ```
 
 ## Where does the data come from?
+
 It's scraped from Apple's Support site. When new Mac models are released `update_models.py` can be run to create a new list. These articles are quite old, and if Apple makes breaking changes to the HTML the Python script might need to be adjusted a bit.
 
 ## My model is missing!
+
 Run the script the make a new PR, or let me know...


### PR DESCRIPTION
When the DEVICE_MODEL_CURL variable is declared, the second DEVICE_IDENTIFIER after grep is being sent as a literal string because the '$' is being escaped with backslash. This causes DEVICE_MODEL and DEVICE_YEAR to be set to unknown and N/A if the mac model in model.txt has two identifiers, and it searches for the second identifier. For example, MacBook Pro (Retina, 15-inch, Mid 2014)|MacBookPro11,2 MacBookPro11,3|2014. If the identifier is MacBookPro11,3 then unknown is returned because grep is searching the literal string '$DEVICE_IDENTIFIER' and not the value of the variable.